### PR TITLE
Update cross_spec/appo/tempo/RegistrationService.scalaRegistrationService.scala pwpolicy

### DIFF
--- a/catalog_manager/conf/cross_spec/appo/tempo/RegistrationService.scala
+++ b/catalog_manager/conf/cross_spec/appo/tempo/RegistrationService.scala
@@ -16,8 +16,8 @@ object RegistrationService {
 
   def requestRegistration(user:IpaUser):Future[Either[String,MailService]] = {
 
-    if (user.userpassword.isEmpty || user.userpassword.get.length <= 5)
-      Future{Left("Password minimum length is 5 character")}
+    if (user.userpassword.isEmpty || user.userpassword.get.length < 8)
+      Future{Left("Password minimum length is 8 characters")}
     else {
       MongoService.findUserByUid(user.uid) match {
         case Right(o) => Future{Left("Username already requested")}


### PR DESCRIPTION
This PR implements what's being described in #124 (password policy, min length of 8 chars)